### PR TITLE
check user agent info

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ http:
 | `logWhiteListAccess` | `boolean` | `false` | Log requests allowed by IP whitelist rules. |
 | `logLevel` | `string` | `"info"` | Log level: `debug`, `info`, `warn`, or `error`. |
 | `logFilePath` | `string` | `""` | Path to save logs to file. If empty, logs only output to Traefik. Can be used for fail2ban integration. |
+| `blockEmptyUserAgent` | `boolean` | `true` | Block requests with an empty User-Agent header. |
 
 ## Logging and fail2ban Integration
 

--- a/geo_access_control.go
+++ b/geo_access_control.go
@@ -49,6 +49,7 @@ type Config struct {
 	LogWhiteListAccess          bool                   `json:"logWhiteListAccess,omitempty"`
 	LogLevel                    string                 `json:"logLevel,omitempty"`
 	LogFilePath                 string                 `json:"logFilePath,omitempty"`
+	BlockEmptyUserAgent         bool                   `json:"blockEmptyUserAgent,omitempty"`
 }
 
 // CreateConfig creates and initializes the default plugin configuration.
@@ -66,6 +67,7 @@ func CreateConfig() *Config {
 		DeniedResponseMessage:       "Not Found",
 		LogLevel:                    "info", // Default log level
 		LogFilePath:                 "",     // Default empty log file path
+		BlockEmptyUserAgent:         true,
 	}
 }
 
@@ -335,6 +337,17 @@ func (g *GeoAccessControl) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 		if re.MatchString(req.URL.Path) {
 			g.logger.Debugf("Path %s matched excluded pattern %s, bypassing geo access control", req.URL.Path, re.String())
 			g.next.ServeHTTP(rw, req)
+			return
+		}
+	}
+
+	if g.config.BlockEmptyUserAgent {
+		userAgent := strings.TrimSpace(req.Header.Get("User-Agent"))
+		if userAgent == "" {
+			if g.config.LogDeniedAccess {
+				g.logger.Warnf("Denied request from IP: %s to %s (empty User-Agent)", clientIP, g.formatURLForLevel(req, g.logger.level))
+			}
+			g.denyRequest(rw, req, "Empty User-Agent is not allowed")
 			return
 		}
 	}

--- a/geo_access_control_test.go
+++ b/geo_access_control_test.go
@@ -206,3 +206,122 @@ func TestCreateConfigCacheTTL(t *testing.T) {
 		t.Errorf("Expected default cacheTTL to be 3600, got %d", config.CacheTTL)
 	}
 }
+
+func TestBlockEmptyUserAgentDefault(t *testing.T) {
+	config := CreateConfig()
+	if config.BlockEmptyUserAgent != true {
+		t.Errorf("Expected default BlockEmptyUserAgent to be true, got %v", config.BlockEmptyUserAgent)
+	}
+}
+
+func TestBlockEmptyUserAgent(t *testing.T) {
+	config := &Config{
+		GeoAPIEndpoint:      "http://test-api",
+		BlockEmptyUserAgent: true,
+		AccessRules: map[string]interface{}{
+			"US": true,
+		},
+	}
+
+	plugin, err := New(context.Background(), nil, config, "test-plugin")
+	if err != nil {
+		t.Fatalf("Failed to create plugin: %v", err)
+	}
+
+	rec := &mockResponseWriter{}
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+
+	plugin.ServeHTTP(rec, req)
+
+	if rec.statusCode != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", rec.statusCode)
+	}
+}
+
+func TestBlockEmptyUserAgentWithUserAgent(t *testing.T) {
+	config := &Config{
+		GeoAPIEndpoint:      "http://test-api",
+		BlockEmptyUserAgent: true,
+		AccessRules: map[string]interface{}{
+			"1.2.3.4": true,
+		},
+	}
+
+	plugin, err := New(context.Background(), nil, config, "test-plugin")
+	if err != nil {
+		t.Fatalf("Failed to create plugin: %v", err)
+	}
+
+	nextCalled := false
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := &mockResponseWriter{}
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+
+	plugin.(*GeoAccessControl).next = nextHandler
+	plugin.ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Error("Expected next handler to be called when User-Agent is present")
+	}
+}
+
+func TestAllowEmptyUserAgent(t *testing.T) {
+	config := &Config{
+		GeoAPIEndpoint:      "http://test-api",
+		BlockEmptyUserAgent: false,
+		AccessRules: map[string]interface{}{
+			"1.2.3.4": true,
+		},
+	}
+
+	plugin, err := New(context.Background(), nil, config, "test-plugin")
+	if err != nil {
+		t.Fatalf("Failed to create plugin: %v", err)
+	}
+
+	nextCalled := false
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := &mockResponseWriter{}
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+
+	plugin.(*GeoAccessControl).next = nextHandler
+	plugin.ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Error("Expected next handler to be called when BlockEmptyUserAgent is false")
+	}
+}
+
+type mockResponseWriter struct {
+	statusCode int
+	header     http.Header
+	body       []byte
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	if m.header == nil {
+		m.header = make(http.Header)
+	}
+	return m.header
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.statusCode = statusCode
+}
+
+func (m *mockResponseWriter) Write(body []byte) (int, error) {
+	m.body = body
+	return len(body), nil
+}


### PR DESCRIPTION
 Log requests to the Geo IP API with User-Agent information in mode debug
Block requests with an empty User-Agent header